### PR TITLE
chore: release 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "plugins": [
     {

--- a/plugins/claude-hud-enhanced/.claude-plugin/plugin.json
+++ b/plugins/claude-hud-enhanced/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud-enhanced",
   "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Alwin Paul",
     "url": "https://github.com/alwinpaul1"

--- a/plugins/claude-hud-enhanced/CHANGELOG.md
+++ b/plugins/claude-hud-enhanced/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.1] - 2026-07-17
 
 ### Fixed
 - **Setup Step 4 no longer contradicts the enhanced defaults**: the optional-features prompt used to claim tools/agents/todos/duration were "hidden by default" and offered to enable them, but those default to **on** in `claude-hud-enhanced`. Step 4 now offers a "Minimal mode" to turn them off (plus config-counts / session-name / custom-line extras) and points to `/claude-hud-enhanced:configure` for deeper tuning.

--- a/plugins/claude-hud-enhanced/package-lock.json
+++ b/plugins/claude-hud-enhanced/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud-enhanced",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/plugins/claude-hud-enhanced/package.json
+++ b/plugins/claude-hud-enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release 0.3.1 (patch)

Version bump `0.3.0 → 0.3.1` across all manifests + CHANGELOG promotion. Ships the post-sync review follow-ups already merged in #32 so they reach installed users (the launcher resolves the latest **version directory**, so a bump is required for propagation).

### Version bumped
- `package.json`, `plugins/.../.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`metadata.version`), `package-lock.json`

### Included fixes (from #32)
- **Setup Step 4** reconciled with the enhanced on-by-default display config (offers "Minimal mode"; defers deep tuning to `/claude-hud-enhanced:configure`).
- **HUD data-dir migration** no longer seeds the legacy `statusline.mjs` launcher (globbed the old `claude-hud` path).
- **Cross-device (EXDEV) migration** now completes the move (copy + remove legacy).
- Regression tests added, incl. an EXDEV rename-seam test.

### Verification
- [x] `npm run build` — green, no `dist/` drift from the bump
- [x] `npm test` — **911 pass / 0 fail / 1 skipped**
- [x] All version strings consistent at 0.3.1 (`git grep` clean; historical `0.3.0` doc/test labels intentionally preserved)

After merge: tag `v0.3.1` on main + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)