### PR TITLE
docs: replace broken star-history SVG with shields.io stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,4 +327,6 @@ MIT — see [LICENSE](LICENSE)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alwinpaul1/claude-hud-enhanced&type=Date)](https://star-history.com/#alwinpaul1/claude-hud-enhanced&Date)
+[![GitHub stars](https://img.shields.io/github/stars/alwinpaul1/claude-hud-enhanced?style=social)](https://star-history.com/#alwinpaul1/claude-hud-enhanced&Date)
+
+*(click for the interactive star-history chart)*


### PR DESCRIPTION
The Star History image in the README rendered broken: `api.star-history.com` returns `503 — All GitHub API tokens are rate-limited`. Replaced the inline SVG with a reliable shields.io social stars badge (verified HTTP 200) that still links to the interactive star-history chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY1mdH7nF62Yhpy2k8DaAD