### PR TITLE
docs: drop star-history caption line under stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,5 +328,3 @@ MIT — see [LICENSE](LICENSE)
 ## Star History
 
 [![GitHub stars](https://img.shields.io/github/stars/alwinpaul1/claude-hud-enhanced?style=social)](https://star-history.com/#alwinpaul1/claude-hud-enhanced&Date)
-
-*(click for the interactive star-history chart)*


### PR DESCRIPTION
Removes the italic "(click for the interactive star-history chart)" caption; the badge alone stays, still linking to the interactive chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY1mdH7nF62Yhpy2k8DaAD