### PR TITLE
fix: 0.4.9 — setup writes statusLine.refreshInterval:5 for idle updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
-    "version": "0.4.8"
+    "version": "0.4.9"
   },
   "plugins": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ Claude Code → stdin JSON → parse → render lines → stdout → Claude Code
            ↘ transcript_path → parse JSONL → tools/agents/todos
 ```
 
-**Key insight**: The statusline is invoked every ~300ms by Claude Code. Each invocation:
+**Key insight**: The statusline is invoked by Claude Code on conversation events
+(new assistant message, `/compact`, permission-mode/vim-mode change), debounced
+at 300ms — plus on a fixed timer while idle when `statusLine.refreshInterval` is
+set (setup writes `5`). Without `refreshInterval` the triggers go quiet while
+idle and the HUD freezes at its last render. Each invocation:
 1. Receives JSON via stdin (model, context, tokens - native accurate data)
 2. Parses the transcript JSONL file for tools, agents, and todos
 3. Renders multi-line output to stdout

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Claude Code → stdin JSON → claude-hud → stdout → displayed in your termi
 **Key features:**
 - Native token data from Claude Code (not estimated)
 - Parses the transcript for tool/agent activity
-- Updates every ~300ms
+- Updates on conversation events (debounced 300ms) and every 5s while idle (`refreshInterval`, written by setup)
 
 ---
 

--- a/plugins/claude-hud-enhanced/.claude-plugin/plugin.json
+++ b/plugins/claude-hud-enhanced/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud-enhanced",
   "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "author": {
     "name": "Alwin Paul",
     "url": "https://github.com/alwinpaul1"

--- a/plugins/claude-hud-enhanced/CHANGELOG.md
+++ b/plugins/claude-hud-enhanced/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.9] - 2026-07-19
+
+### Fixed
+- **Setup now writes `statusLine.refreshInterval: 5` — required for any idle-time updates.** Root cause of "idle terminals never pick up usage from active ones": Claude Code only re-runs the statusline on conversation events (new assistant message, `/compact`, permission-mode/vim-mode change; debounced 300ms) and those triggers **go quiet while a session is idle** — so an idle terminal's HUD froze at its last render no matter what the plugin computed. The hybrid usage sync (0.4.6), idle usage reset (0.4.5), and the all-idle OAuth refresher trigger (0.4.7) all depend on idle repaints; the 5s refresh timer makes them actually visible/fire. Existing installs: add `"refreshInterval": 5` to the `statusLine` block in `settings.json` (or re-run `/claude-hud-enhanced:setup`). Docs corrected — the HUD is *not* invoked every ~300ms unconditionally.
+
 ## [0.4.8] - 2026-07-19
 
 ### Fixed

--- a/plugins/claude-hud-enhanced/commands/setup.md
+++ b/plugins/claude-hud-enhanced/commands/setup.md
@@ -670,10 +670,19 @@ If a write fails with `File has been unexpectedly modified`, re-read the file an
 {
   "statusLine": {
     "type": "command",
-    "command": "{GENERATED_COMMAND}"
+    "command": "{GENERATED_COMMAND}",
+    "refreshInterval": 5
   }
 }
 ```
+
+**`refreshInterval` is required for idle updates.** Claude Code only re-runs the
+statusline on conversation events (new assistant message, `/compact`, permission
+mode change, vim mode toggle) — those triggers go quiet while the session is
+idle. The 5-second timer keeps the HUD live when nothing is happening in the
+terminal: the session-duration clock ticks, cross-terminal usage sync
+(`oauthUsagePoll`) actually appears in idle terminals, idle usage reset fires at
+window rollover, and the all-idle OAuth refresher can trigger at all.
 
 **JSON safety**: Write `settings.json` with a real JSON serializer or editor API, not manual string concatenation.
 If you must inspect the saved JSON manually, the embedded bash command must preserve escaped backslashes inside the awk fragment.

--- a/plugins/claude-hud-enhanced/package-lock.json
+++ b/plugins/claude-hud-enhanced/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud-enhanced",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/plugins/claude-hud-enhanced/package.json
+++ b/plugins/claude-hud-enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Root cause of "idle terminals never pick up usage from active ones": per the official statusline docs, Claude Code re-runs the statusline only on conversation events (new assistant message, `/compact`, permission-mode/vim-mode change; debounced 300ms) — and those triggers **go quiet while a session is idle**. An idle terminal's HUD therefore froze at its last render regardless of what the plugin computed (verified: the reader logic serves the fresher shared snapshot correctly when invoked).

- `/claude-hud-enhanced:setup` now writes `"refreshInterval": 5` into the `statusLine` block, the documented mechanism for idle-time re-runs.
- This is what makes hybrid usage sync (0.4.6), idle usage reset (0.4.5), and the all-idle OAuth refresher trigger (0.4.7) actually visible/fire while idle.
- Corrected CLAUDE.md/README claims that the HUD is invoked "every ~300ms" unconditionally.
- Existing installs: add `"refreshInterval": 5` to `statusLine` in `settings.json` or re-run setup.

Tests: 968 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY1mdH7nF62Yhpy2k8DaAD