### PR TITLE
feat: 0.4.10 — setup benchmarks render time to pick refreshInterval (2/5/10s)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
-    "version": "0.4.9"
+    "version": "0.4.10"
   },
   "plugins": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ Claude Code → stdin JSON → parse → render lines → stdout → Claude Code
 **Key insight**: The statusline is invoked by Claude Code on conversation events
 (new assistant message, `/compact`, permission-mode/vim-mode change), debounced
 at 300ms — plus on a fixed timer while idle when `statusLine.refreshInterval` is
-set (setup writes `5`). Without `refreshInterval` the triggers go quiet while
+set (setup benchmarks the render and writes `2`, `5`, or `10` — fastest the
+machine can afford). Without `refreshInterval` the triggers go quiet while
 idle and the HUD freezes at its last render. Each invocation:
 1. Receives JSON via stdin (model, context, tokens - native accurate data)
 2. Parses the transcript JSONL file for tools, agents, and todos

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Claude Code → stdin JSON → claude-hud → stdout → displayed in your termi
 **Key features:**
 - Native token data from Claude Code (not estimated)
 - Parses the transcript for tool/agent activity
-- Updates on conversation events (debounced 300ms) and every 5s while idle (`refreshInterval`, written by setup)
+- Updates on conversation events (debounced 300ms) and on a timer while idle (`refreshInterval` — setup benchmarks your machine and writes 2s/5s/10s)
 
 ---
 

--- a/plugins/claude-hud-enhanced/.claude-plugin/plugin.json
+++ b/plugins/claude-hud-enhanced/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud-enhanced",
   "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "author": {
     "name": "Alwin Paul",
     "url": "https://github.com/alwinpaul1"

--- a/plugins/claude-hud-enhanced/CHANGELOG.md
+++ b/plugins/claude-hud-enhanced/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.10] - 2026-07-19
+
+### Changed
+- **Setup now benchmarks the machine and picks the fastest safe `refreshInterval` (2/5/10s)** instead of a flat 5s. The idle-repaint cost is the HUD's own render time (runtime spawn + transcript parse + git), which varies ~30× across hardware: Apple Silicon + bun renders in ~90ms warm (2s is cheap, ~5% of a core), older Intel/node lands 150–500ms (5s), and slow-spawn environments (Windows especially) can exceed 500ms (10s; Windows also gets a hard floor of 5s). The interval must comfortably exceed the render time — Claude Code cancels in-flight runs on each new tick, so an interval the render can't keep up with means the HUD may never finish a paint (the failure mode ccstatusline's diagnostics warn about for inline commands ≤2s). Setup times 3 runs of the generated command and picks the tier from the fastest.
+
 ## [0.4.9] - 2026-07-19
 
 ### Fixed

--- a/plugins/claude-hud-enhanced/commands/setup.md
+++ b/plugins/claude-hud-enhanced/commands/setup.md
@@ -444,13 +444,40 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
 
 **WSL (Windows Subsystem for Linux)**: If running in WSL, use the macOS/Linux instructions. Ensure the plugin is installed in the Linux environment (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/...`), not the Windows side.
 
-## Step 2: Test Command
+## Step 2: Test Command and Benchmark Refresh Interval
 
 Run the generated command. It should produce output (the HUD lines) within a few seconds.
 
 - If it errors, do not proceed to Step 3.
 - If it hangs for more than a few seconds, cancel and debug.
 - This test catches issues like broken runtime binaries, missing plugins, or path problems.
+
+### 2.1: Benchmark to pick `refreshInterval`
+
+The idle repaint timer should be as fast as this machine can afford. Run the
+generated command **3 times**, timing each run's wall clock (feed it the same
+empty-stdin input as the test above). The first run is a cold start — take the
+**fastest** of the three as the machine's render time. Timing recipe (macOS
+lacks `date +%N`; use the runtime you already validated):
+
+```bash
+node -e 'const{execSync}=require("child_process");const t=Date.now();execSync(process.argv[1],{stdio:"ignore",shell:true});console.log(Date.now()-t+"ms")' '{GENERATED_COMMAND} < /dev/null'
+```
+
+Pick the tier:
+
+| Fastest render | `refreshInterval` |
+|---|---|
+| < 150 ms | `2` |
+| 150–500 ms | `5` |
+| > 500 ms | `10` |
+
+**Windows floor**: on `win32` always use at least `5` regardless of the
+benchmark — process spawn overhead there is high-variance (see the Windows
+launcher notes above), and an interval the render can't keep up with makes
+Claude Code cancel in-flight runs on every tick, so the HUD may never finish a
+paint. The same logic is why the interval must comfortably exceed the measured
+render time everywhere.
 
 ## Step 2.5: Detect Existing Statusline and Create Backup
 
@@ -671,10 +698,13 @@ If a write fails with `File has been unexpectedly modified`, re-read the file an
   "statusLine": {
     "type": "command",
     "command": "{GENERATED_COMMAND}",
-    "refreshInterval": 5
+    "refreshInterval": {BENCHMARKED_INTERVAL}
   }
 }
 ```
+
+`{BENCHMARKED_INTERVAL}` comes from the Step 2.1 benchmark (2, 5, or 10; use 5
+if the benchmark could not run).
 
 **`refreshInterval` is required for idle updates.** Claude Code only re-runs the
 statusline on conversation events (new assistant message, `/compact`, permission

--- a/plugins/claude-hud-enhanced/package-lock.json
+++ b/plugins/claude-hud-enhanced/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud-enhanced",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/plugins/claude-hud-enhanced/package.json
+++ b/plugins/claude-hud-enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Enhanced real-time statusline HUD for Claude Code - color themes, accurate token display, context health, tool activity, agent tracking, and todo progress",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Determines the best-and-fastest idle repaint interval **per machine** instead of shipping one flat number.

Why: the repaint cost is the HUD's own render time (runtime spawn + transcript parse + git status), which varies ~30× across hardware — ~90ms warm on Apple Silicon + bun, 150–500ms on older Intel/node, >500ms on slow-spawn environments (Windows especially). Claude Code cancels an in-flight statusline run whenever a new tick fires, so an interval shorter than the render time can thrash and never complete a paint (the failure mode ccstatusline's diagnostics flag for inline commands ≤2s).

Changes:
- `/claude-hud-enhanced:setup` Step 2 now times 3 runs of the generated command (fastest counts) and writes `refreshInterval` from a tier table: <150ms → 2s, 150–500ms → 5s, >500ms → 10s; hard floor of 5s on Windows.
- Fallback to 5 if the benchmark can't run.
- CLAUDE.md / README updated to describe the adaptive behavior.

Tests: 968 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY1mdH7nF62Yhpy2k8DaAD