### PR TITLE
chore(deps,ci): patch the brace-expansion DoS and move every action off Node 20

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -23,11 +23,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[auto]')"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm
@@ -26,6 +26,6 @@ jobs:
           npm test
           npm run test:coverage
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/plugins/claude-hud-enhanced/package-lock.json
+++ b/plugins/claude-hud-enhanced/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud-enhanced",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud-enhanced",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -434,16 +434,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {


### PR DESCRIPTION
Two pieces of housekeeping, both surfaced by the 0.7.0 release run. Small and independent.

## 1. brace-expansion DoS (high — Dependabot alert 9)

Denial of service via exponential-time expansion of consecutive non-matching braces. Reached transitively as `c8 → test-exclude → minimatch → brace-expansion`, pinned at **5.0.4** in the lockfile; patched in **5.0.7**.

Bumped to **5.0.9** with `npm update brace-expansion --package-lock-only`, so only the lockfile moves — no declared dependency range changes. `npm audit` now reports **0 vulnerabilities**.

## 2. Every action moved off the deprecated Node 20

The v0.7.0 release run warned that `actions/checkout@v4`, `actions/setup-node@v4` and `softprops/action-gh-release@v2` all target Node 20 and are being forced onto Node 24.

Verified against each action's own `action.yml` rather than guessed — `checkout` v6/v7, `setup-node` v6/v7 and `action-gh-release` v3 all declare `using: node24`.

**Chose v6 for checkout and setup-node rather than the newest v7,** because v6 is already green in this repo: the `windows-git` job added in 0.7.0 uses it. That makes this the smallest change that clears the warning.

It also fixes an inconsistency 0.7.0 introduced: `ci.yml`'s `windows-git` job was on v6 while the `test` job directly above it was still on v4.

`action-gh-release` goes **v2 → v3**, the only version that clears its warning.

## Worth watching

`action-gh-release` v2 → v3 is a **major** bump on the release-publishing path, and it **only exercises on the next tag push**, not in this PR's CI. If a future release run fails at the "Create release" step, this is the first thing to look at.

## Verification

- All four workflow files parse
- `npm ci` installs cleanly from the updated lockfile
- `1205 tests, 1199 pass, 0 fail`
- A rebuild leaves `dist/` byte-identical, so the committed build still matches source

Reviewers running the suite locally must `unset CLAUDE_CONFIG_DIR` first — with it set, 55 tests fail on an untouched `main` too, because they assume the default profile.
